### PR TITLE
[SERV-83] Skip Rows With Unfound Media

### DIFF
--- a/src/main/java/edu/ucla/library/services/metadata/MetadataSetter.java
+++ b/src/main/java/edu/ucla/library/services/metadata/MetadataSetter.java
@@ -365,7 +365,7 @@ public final class MetadataSetter implements Callable<Integer> {
             }
         } catch (final IOException details) {
             // We want to distinguish between this IOException and one that comes from reading/writing the CSV file
-            throw new FfProbeException(details, filePath);
+            System.err.println(LOGGER.getMessage(MessageCodes.MG_106, filePath, details.getMessage()));
         }
     }
 

--- a/src/main/java/edu/ucla/library/services/metadata/MetadataSetter.java
+++ b/src/main/java/edu/ucla/library/services/metadata/MetadataSetter.java
@@ -252,8 +252,6 @@ public final class MetadataSetter implements Callable<Integer> {
             for (final String[] row : output) {
                 writer.writeNext(row);
             }
-        } catch (final FfProbeException details) {
-            throw new I18nRuntimeException(details, MessageCodes.BUNDLE, MessageCodes.MG_000, details.getMessage());
         } catch (final IOException details) { // Catches FileNotFoundException(s) and other IOException(s), too
             throw new I18nRuntimeException(details, MessageCodes.BUNDLE, MessageCodes.MG_104, details.getMessage());
         } catch (final FileFormatException details) {
@@ -288,7 +286,7 @@ public final class MetadataSetter implements Callable<Integer> {
      * @throws FileFormatException If the media file doesn't have a file extension
      */
     private String[] buildARow(final boolean aHasColumns, final String... aSource)
-            throws FileNotFoundException, FfProbeException, FileFormatException {
+            throws FileNotFoundException, FileFormatException {
         final int fileColumnIndex = myCsvHeaders.getFileNameIndex();
         final String[] line = Arrays.copyOf(aSource, aHasColumns ? aSource.length : aSource.length + 4);
         final String fileName = line[fileColumnIndex];
@@ -327,7 +325,7 @@ public final class MetadataSetter implements Callable<Integer> {
      * @throws FileNotFoundException If a media file could be found
      * @throws FfProbeException If FFProbe encounters an error while reading the media file
      */
-    private void addMetadata(final String... aRow) throws FileNotFoundException, FfProbeException {
+    private void addMetadata(final String... aRow) {
         final String filePath = aRow[myCsvHeaders.getFileNameIndex()];
 
         try {
@@ -364,7 +362,6 @@ public final class MetadataSetter implements Callable<Integer> {
                 }
             }
         } catch (final IOException details) {
-            // We want to distinguish between this IOException and one that comes from reading/writing the CSV file
             System.err.println(LOGGER.getMessage(MessageCodes.MG_106, filePath, details.getMessage()));
         }
     }

--- a/src/test/java/edu/ucla/library/services/metadata/MetadataSetterTest.java
+++ b/src/test/java/edu/ucla/library/services/metadata/MetadataSetterTest.java
@@ -168,7 +168,7 @@ public class MetadataSetterTest {
             MetadataSetter.main(new String[] { CSV_WITH_BAD_MEDIA, COMBINED_MEDIA_PATHS, FFMPEG_PATH, OUTPUT_PATH });
         });
         assertEquals(ExitCodes.SUCCESS, statusCode);
-	assertTrue(mySystemErrRule.getLog().trim().contains(errorMessage));
+        assertTrue(mySystemErrRule.getLog().trim().contains(errorMessage));
     }
 
     /**

--- a/src/test/java/edu/ucla/library/services/metadata/MetadataSetterTest.java
+++ b/src/test/java/edu/ucla/library/services/metadata/MetadataSetterTest.java
@@ -163,15 +163,12 @@ public class MetadataSetterTest {
      */
     @Test
     public void testGetMetaFromBadFileMultipleMediaPaths() throws Exception {
-        final String ffprobeMessage = "/usr/bin/ffprobe returned non-zero exit status." + System.lineSeparator();
+        final String errorMessage = "Problem reading media file";
         final int statusCode = catchSystemExit(() -> {
             MetadataSetter.main(new String[] { CSV_WITH_BAD_MEDIA, COMBINED_MEDIA_PATHS, FFMPEG_PATH, OUTPUT_PATH });
         });
-        assertEquals(ExitCodes.READ_WRITE_ERROR, statusCode);
-        assertEquals(
-                LOGGER.getMessage(MessageCodes.MG_106, "bad-mp3-file.mp3",
-                        ffprobeMessage + LOGGER.getMessage(MessageCodes.MG_109)),
-                mySystemErrRule.getLog().trim().replaceAll(System.getProperty("line.separator"), " "));
+        assertEquals(ExitCodes.SUCCESS, statusCode);
+	assertTrue(mySystemErrRule.getLog().trim().contains(errorMessage));
     }
 
     /**

--- a/src/test/java/edu/ucla/library/services/metadata/MetadataSetterTest.java
+++ b/src/test/java/edu/ucla/library/services/metadata/MetadataSetterTest.java
@@ -163,12 +163,14 @@ public class MetadataSetterTest {
      */
     @Test
     public void testGetMetaFromBadFileMultipleMediaPaths() throws Exception {
-        final String errorMessage = "Problem reading media file";
+        final String badMedia = "bad-mp3-file.mp3";
+        final String probeError = "/usr/bin/ffprobe returned non-zero exit status. Check stdout.";
+        final String errorMessage = LOGGER.getMessage(MessageCodes.MG_106, badMedia, probeError);
         final int statusCode = catchSystemExit(() -> {
             MetadataSetter.main(new String[] { CSV_WITH_BAD_MEDIA, COMBINED_MEDIA_PATHS, FFMPEG_PATH, OUTPUT_PATH });
         });
         assertEquals(ExitCodes.SUCCESS, statusCode);
-        assertTrue(mySystemErrRule.getLog().trim().contains(errorMessage));
+        assertEquals(mySystemErrRule.getLog().trim(), errorMessage);
     }
 
     /**


### PR DESCRIPTION
Updates:
* Modified `MetadataSetter.java` to produce CL message when referenced media file not found
* Modified unit test to check for new CL message