### PR TITLE
Assert success in tests where it is expected

### DIFF
--- a/src/test/java/edu/ucla/library/services/metadata/MetadataSetterTest.java
+++ b/src/test/java/edu/ucla/library/services/metadata/MetadataSetterTest.java
@@ -127,6 +127,9 @@ public class MetadataSetterTest {
         // Nb: value comes from src/test/resources/media/ephraim/audio/21198-zz000954s4-2-submaster.mp3
         final String formattedDuration = "12m 37s";
         final Path updatedCsv = FileSystems.getDefault().getPath(OUTPUT_PATH + CSV_NAME);
+
+        assertEquals(ExitCodes.SUCCESS, statusCode);
+
         try (CSVReader reader = new CSVReader(new FileReader(updatedCsv.toFile()))) {
             final List<String[]> rows = reader.readAll();
             final CsvHeaders headers = new CsvHeaders(rows.get(0));
@@ -150,6 +153,9 @@ public class MetadataSetterTest {
         // Nb: value comes from src/test/resources/media/ephraim/video/crowd.mpg
         final String videoFormat = "video/mpeg";
         final Path updatedCsv = FileSystems.getDefault().getPath(OUTPUT_PATH + CSV_NAME);
+
+        assertEquals(ExitCodes.SUCCESS, statusCode);
+
         try (CSVReader reader = new CSVReader(new FileReader(updatedCsv.toFile()))) {
             final List<String[]> rows = reader.readAll();
             final CsvHeaders headers = new CsvHeaders(rows.get(0));
@@ -170,6 +176,9 @@ public class MetadataSetterTest {
         });
 
         final Path updatedCsv = FileSystems.getDefault().getPath(OUTPUT_PATH + CSV_NAME);
+
+        assertEquals(ExitCodes.SUCCESS, statusCode);
+
         try (CSVReader reader = new CSVReader(new FileReader(updatedCsv.toFile()))) {
             final List<String[]> rows = reader.readAll();
             final CsvHeaders headers = new CsvHeaders(rows.get(0));

--- a/src/test/java/edu/ucla/library/services/metadata/MetadataSetterTest.java
+++ b/src/test/java/edu/ucla/library/services/metadata/MetadataSetterTest.java
@@ -134,7 +134,7 @@ public class MetadataSetterTest {
             final List<String[]> rows = reader.readAll();
             final CsvHeaders headers = new CsvHeaders(rows.get(0));
             assertEquals(rows.get(2)[headers.getFormatExtentIndex()], formattedDuration);
-        } catch (IOException details) {
+        } catch (final IOException details) {
             fail(details.getMessage());
         }
     }
@@ -161,7 +161,7 @@ public class MetadataSetterTest {
             final CsvHeaders headers = new CsvHeaders(rows.get(0));
             assertEquals(rows.get(2)[headers.getMediaFormatIndex()], audioFormat);
             assertEquals(rows.get(4)[headers.getMediaFormatIndex()], videoFormat);
-        } catch (IOException details) {
+        } catch (final IOException details) {
             fail(details.getMessage());
         }
     }
@@ -188,7 +188,7 @@ public class MetadataSetterTest {
             final String duration = rows.get(3)[headers.getMediaDurationIndex()].trim();
             final String format = rows.get(3)[headers.getMediaFormatIndex()].trim();
             assertTrue(width.equals(EMPTY) && height.equals(EMPTY) && duration.equals(EMPTY) && format.equals(EMPTY));
-        } catch (IOException details) {
+        } catch (final IOException details) {
             fail(details.getMessage());
         }
     }


### PR DESCRIPTION
While installing this on production, I noticed that a few tests were failing later than they could be. The output CSV file wasn't being created, but the root cause was that ffprobe was missing from the system (rather than, say, an issue with write permissions). This change reveals that root cause.